### PR TITLE
page statistiques: ajout de l'ecart type des notes dans le tableau de…

### DIFF
--- a/stat_barre.php
+++ b/stat_barre.php
@@ -379,6 +379,7 @@ $count_data_annee = count($data_annee);
           <th>Proposeur</th>
           <th>Moyenne</th>
           <th>Nombre de notes</th>
+          <th>Écart type</th>
         </tr>
       </thead>
       <tbody>
@@ -401,6 +402,7 @@ $count_data_annee = count($data_annee);
             <td><?php echo htmlspecialchars($film->propositions[0]->semaine->proposeur->nom); ?></td>
             <td><?php echo rtrim(rtrim(number_format($film->moyenne, 2), '0'), '.'); ?></td>
             <td><?php echo $nb_notes . ($nb_notes == 1 ? " note" : " notes"); ?></td>
+            <td><?php echo is_null($film->ecartType) ? "-" : $film->ecartType . " - " . ($film->ecartType > 2 ? "clivant" : "consensuel") ?></td>
           </tr>
         <?php endforeach; ?>
       </tbody>


### PR DESCRIPTION
page statistiques: 
ajout de l'ecart type des notes dans le tableau des films gagnants

un ecart type au dela de la valeur "2" est considéré clivant
cette valeur a été fixée de maniere arbitraire

--
Evolution requise de l'api: https://github.com/Greenwood-Consulting/CinePS-API/pull/31
