### PR TITLE
fix: affiche theme au proposeur

### DIFF
--- a/index.php
+++ b/index.php
@@ -44,7 +44,7 @@ if(isset($_POST['end_proposition'])){//si on appui sur le bouton "proposition te
 }
 
 //si on valide le theme
-if(isset($_POST['new_theme'])){
+if(isset($_POST['update_theme'])){
   // préparation du body de la requête POST
   $array_semaine = array(
     'theme' => $_POST['theme_film']
@@ -391,18 +391,12 @@ if ($json_current_semaine[0]->type == "PSAvecFilm") {
           ?>
 
           <form method="POST" action="index.php">
-          <label> Proposition de films:</label>
-            <?php
 
-            // @TODO : sortir dans un formulaire à part le formulaire du thème ?
-            if($etat_theme_non_propose){//si pas de thème déjà défini, on affiche le formulaire de proposition de thème
-            // @TODO : si thème défini, afficher le thème ou alors
-            // Afficher le formulaire avec le thème pré-saisi ?
-              echo '<input type="text" name="theme_film" placeholder="Thème film" class="text-dark"/>
-                    <button type="submit" name="new_theme" class="btn btn-warning">Choisissez un thème</button><br/><br/>';
-            }
-            ?>
+            <label>Thème:</label>
+            <input type="text" name="theme_film" placeholder="Thème des films" class="text-dark" value="<?= $json_current_semaine[0]->theme ?>" />
+            <button type="submit" name="update_theme" class="btn btn-warning"><?= $etat_theme_non_propose? "Choisissez un thème" : "Modifiez le thème" ?></button><br/><br/>
             
+            <label>Proposition:</label>
             <input type="text" name="titre_film"  placeholder="Titre du film" class="text-dark" />
             <input type="text" name="lien_imdb" placeholder="Lien imdb" class="text-dark"/>
             <input type="number" name="date"  placeholder="Année" class="text-dark" >

--- a/index.php
+++ b/index.php
@@ -397,17 +397,20 @@ if ($json_current_semaine[0]->type == "PSAvecFilm") {
             <button type="submit" name="update_theme" class="btn btn-warning"><?= $etat_theme_non_propose? "Choisissez un thème" : "Modifiez le thème" ?></button><br/><br/>
             
             <label>Proposition:</label>
+            <!-- Proposition classique -->
             <input type="text" name="titre_film"  placeholder="Titre du film" class="text-dark" />
             <input type="text" name="lien_imdb" placeholder="Lien imdb" class="text-dark"/>
             <input type="number" name="date"  placeholder="Année" class="text-dark" >
-            <button type="submit" name="new_proposition" class="btn btn-warning">Proposer</button><br/>
+            <button type="submit" name="new_proposition" class="btn btn-warning">Proposer un film</button><br/>
             <button type="submit" name="end_proposition"  class="btn btn-warning">Valider les Propositions</button><br/><br/>
 
+            <!-- Proposition seconde chance -->
             <button type="submit" name="seconde_chance" class="btn btn-warning">Seconde Chance</button><br /><br />
 
+            <!-- Proposition ChatGPT -->
             <button type="button" onclick="openPopup()" class="btn btn-warning">ChatGPT</button>
 
-            <!-- Overlay et contenu du pop-up -->
+            <!-- Overlay et contenu du pop-up pour Proposition ChatGPT-->
             <div class="overlay" id="popup-overlay">
               <div class="popup" onclick="event.stopPropagation();">
                 <!-- Bouton de fermeture en tant que span -->


### PR DESCRIPTION

- le champ input est utilisé à la fois pour créer le thème et pour l'afficher
- l'input n'est pas desactivé après la création du thème, ce qui permet en bonus la modification du thème par l'utilisateur
- le texte du bouton s'adapte dynamiquement:  "Choisissez un thème" / "Modifiez le thème"
- refacto
- clarification des textes

theme **non** proposé:
![image](https://github.com/user-attachments/assets/6b44b354-201e-4e15-8bf9-ea1e9358fc3a)

theme proposé:
![image](https://github.com/user-attachments/assets/70c102af-0185-4e42-80b5-ed101da09488)
