### PR TITLE
fix inconsistent text: les propositions ont été faites

### DIFF
--- a/index.php
+++ b/index.php
@@ -290,8 +290,6 @@ if ($json_current_semaine->type == "PSAvecFilm") {
 
   if ($json_current_semaine->proposition_termine){
     echo '<span class="text-warning">Il reste <div id="demo"></div> avant la fin du vote</span>';
-  } else {
-    echo '<mark>Les propositions ont été faites pour cette semaine</mark>';
   }
   echo '<br/>';
 


### PR DESCRIPTION
le texte "les propositions ont été faites" apparait dans le cas ou le proposeur n'a pas encore fait de propositions

il y a un doublon avec le texte juste en dessous qui lui est cohérent

<img width="727" height="454" alt="image" src="https://github.com/user-attachments/assets/94d8204f-2845-4cf6-b4a5-a807fad7397f" />
