### PR TITLE
🚀add common deploy exclude file [.lftp-exclude]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,11 @@ jobs:
 
     - name: Upload files via SFTP
       run: |
-        lftp -f "
+        lftp <<EOF
         set sftp:connect-program 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
         open -u ${{ secrets.PREPROD_FTP_USER }},${{ secrets.PREPROD_FTP_PASSWORD }} sftp://${{ secrets.PREPROD_FTP_HOST }}
-        mirror -R --delete ./ /lamp0/web/vhosts/preprod-ps.gc2.fr/htdocs --exclude .git/ --exclude .github/ --exclude .htaccess --exclude .htpasswd --exclude .gitignore --exclude config/env.php
+        mirror -R --delete ./ /vhosts/preprod-ps.gc2.fr/htdocs --exclude-glob-from .lftp-exclude
         bye
-        "
+        EOF
 
             

--- a/.github/workflows/prod_AWS_EC2_deploy.yml
+++ b/.github/workflows/prod_AWS_EC2_deploy.yml
@@ -23,11 +23,11 @@ jobs:
 
     - name: Upload files via SFTP
       run: |
-        lftp -f "
+        lftp <<EOF
         set sftp:connect-program 'ssh -a -x -i ~/.ssh/id_rsa'
         open -u ${{ secrets.PROD_AWS_EC2_USER }}, sftp://${{ secrets.PROD_AWS_EC2_HOST_IP }}
-        mirror -R --delete ./ /var/www/CinePS --exclude .git/ --exclude .htaccess --exclude config/env.php
+        mirror -R --delete ./ /var/www/CinePS --exclude-glob-from .lftp-exclude
         bye
-        "
+        EOF
 
             

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -16,11 +16,11 @@ jobs:
 
     - name: Upload files via SFTP
       run: |
-        lftp -f "
+        lftp <<EOF
         set sftp:connect-program 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
         open -u ${{ secrets.PROD_FTP_USER }},${{ secrets.PROD_FTP_PASSWORD }} sftp://${{ secrets.PROD_FTP_HOST }}
-        mirror -R --delete ./ /lamp0/web/vhosts/ps.gc2.fr/htdocs --exclude .git/ --exclude .github/ --exclude .htaccess --exclude .htpasswd --exclude .gitignore --exclude config/env.php --exclude debug.php
+        mirror -R --delete ./ /vhosts/ps.gc2.fr/htdocs --exclude-glob-from .lftp-exclude
         bye
-        "
+        EOF
 
             

--- a/.lftp-exclude
+++ b/.lftp-exclude
@@ -1,0 +1,14 @@
+# fichiers/dossiers à ignorer lors du deploiement en preprod/prod
+# - ce qui est inutile pour le fonctionnement du serveur
+.git/**
+.github/**
+.gitignore
+.lftp-exclude
+debug.php
+README.md
+scripts/**
+
+# - ce qui ne doit pas être supprimé du serveur
+.htaccess
+.htpasswd
+config/env.php


### PR DESCRIPTION
Comme ce qui a été fait coté api (https://github.com/Greenwood-Consulting/CinePS-API/pull/63), mise en place d'un fichier contenant la liste des exclusions lors des deploiements.

Adaptation des commandes de deploiement pour utiliser ce nouveau fichier de conf

La commande mirror a été directement testée en pre-prod, mais pas le fichier github actions


Un inconvenient cependant: le fichier debug.php devra être deployé manuellement en preprod (si besoin)